### PR TITLE
Added membership Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership.md
+++ b/.github/ISSUE_TEMPLATE/membership.md
@@ -1,0 +1,40 @@
+---
+name: Organization Membership Request
+about: Request membership in Keptn Org
+title: 'REQUEST: New membership for <your-GH-handle>'
+labels: area/github-membership
+assignees: ''
+
+---
+
+<!-- Please remember to change the title of this issue by replacing
+ <your-GH-handle> with the actual GitHub handle -->
+
+### GitHub Username
+
+e.g. (at)example_user
+
+### Requirements
+
+- [ ] I have reviewed the community membership guidelines (https://github.com/keptn/community/blob/master/COMMUNITY_MEMBERSHIP.md)
+- [ ] I have enabled 2FA on my GitHub account. See https://github.com/settings/security
+- [ ] I have subscribed to the [Keptn Slack channel](http://slack.keptn.sh/)
+- [ ] I am actively contributing to 1 or more Keptn subprojects
+- [ ] I have two sponsors that meet the sponsor requirements listed in the community membership guidelines. Among other requirements, sponsors must be approvers or maintainers of at least one repository in the organization and not both affiliated with the same company
+- [ ] I have spoken to my sponsors ahead of this application, and they have agreed to sponsor my application
+
+### Sponsors
+
+<!-- Replace (at) with the `@` sign -->
+
+- (at)sponsor-1
+- (at)sponsor-2
+
+Each sponsor should reply to this issue with the comment "*I support*".
+Please remember, it is an applicant's responsibility to get their sponsors' confirmation before submitting the request.
+
+### List of contributions to the Keptn project
+
+- PRs reviewed / authored
+- Issues responded to
+- SIG projects I am involved with


### PR DESCRIPTION
To request membership for the Keptn project, the template behind the `Open issue` was missing. Consequently, it was not possible to sign up for a Keptn membership, by following the instructions here: 

![image](https://user-images.githubusercontent.com/729071/119862662-05f59400-bf19-11eb-83af-79764ad07ee4.png)

This PR adds the Issue template a candidate has to fill out for membership. 

Signed-off-by: Johannes <johannes.braeuer@dynatrace.com>