### PR TITLE
Create issue template for community management ideas

### DIFF
--- a/.github/ISSUE_TEMPLATE/community-management.md
+++ b/.github/ISSUE_TEMPLATE/community-management.md
@@ -1,0 +1,27 @@
+---
+name: Community Enhacement
+about: Use it for any proposals for improving the community and tooling around it 
+title: 'RFE: <summary>'
+labels: enhancement
+assignees: ''
+
+---
+
+### Proposal
+
+<!-- Summarize your idea here -->
+
+### References
+
+
+### Sponsors
+
+<!-- Mention Keptn maintainer sponsors here, if any -->
+
+- (at)sponsor-1
+- (at)sponsor-2
+
+### Checklist
+
+- [ ] The idea is brought up for a discussion in a relevant Keptn Slack channel (use `#keptn-project` by default)
+- [ ] Each sponsor should reply to this issue with the comment "*I support*".


### PR DESCRIPTION
I would like to create a backlog of various community enhancement ides so that we can track what we're doing in the Keptn community and discuss the ideas. Basically it can be used as a lightweight equivalent of KEPs for community management