### PR TITLE
Change the label for the community management template

### DIFF
--- a/.github/ISSUE_TEMPLATE/community-management.md
+++ b/.github/ISSUE_TEMPLATE/community-management.md
@@ -1,8 +1,8 @@
 ---
-name: Community Enhacement
-about: Use it for any proposals for improving the community and tooling around it 
+name: Community Management & Governance
+about: Use it for any proposals for improving the community, governance and tooling around it 
 title: 'RFE: <summary>'
-labels: enhancement
+labels: community
 assignees: ''
 
 ---


### PR DESCRIPTION
`enhancement` is used for the technical tasks on the roadmap, and we do not want to have collisions. Contributes to #67 

Signed-of-by: Oleg Nenashev <o.v.nenashev@gmail.com>