### PR TITLE
Fix Enhacement typo

### DIFF
--- a/.github/ISSUE_TEMPLATE/community-management.md
+++ b/.github/ISSUE_TEMPLATE/community-management.md
@@ -1,5 +1,5 @@
 ---
-name: Community Enhacement
+name: Community Enhancement
 about: Use it for any proposals for improving the community and tooling around it 
 title: 'RFE: <summary>'
 labels: enhancement


### PR DESCRIPTION
Fix a small typo in the title: `Enhacement  >> Enhancement`