### PR TITLE
Document mentorship and outreach programs, including LFX mentorship

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ that is given on a quarterly basis.
 There are also some resources stored in this repository or elsewhere:
 
 * [Community Roadmap](https://github.com/orgs/keptn/projects/1?card_filter_query=label%3Acommunity) - Major community initiatives
-  as a part of the Keptn roadmap
-* [Artwork](./logos) - Keptn logos and artwork
+  as a part of the Keptn roadmap.
+* [Mentorship and Outreach programs](./mentorship/README.md) -
+  programs we participate in. 
+* [Artwork](./logos) - Keptn logos and artwork.
 * [Keptn Project Infrastructure](./project-infrastructure/) - 
   Documentation and notes regarding the project infrastructure being used by the project:
   website, delivery infrastructure, repositories and services, etc.

--- a/mentorship/README.md
+++ b/mentorship/README.md
@@ -1,0 +1,16 @@
+# Mentorship programs in Keptn
+
+[![Channel on Slack](https://img.shields.io/badge/Slack-%23advocacy--and--outreach-green)](https://keptn.sh/community/#slack)
+
+Keptn regularly participates in international mentorship and outreach programs.
+We invite potential mentors and mentees to join the community and
+to participate in one of these programs.
+
+Examples of programs we've participated in:
+
+- [LFX Mentorship / CommunityBridge](./lfx-mentorship)
+- [Google Summer of Code](./gsoc/)
+- [Google Season of Docs](./gsod)
+- [Hacktoberfest](https://hacktoberfest.digitalocean.com/)
+- Bug Bash at Kubecon conferences
+

--- a/mentorship/lfx-mentorship/README.md
+++ b/mentorship/lfx-mentorship/README.md
@@ -8,8 +8,8 @@ The Keptn community can host mentorship and outreach programs using
 
 ## Scope
 
-We can run projects there on ad-hoc basis,
-barring we have mentors and budgets available.
+We can run LFX Mentorship projects on an ad-hoc basis,
+assuming we have mentors and budgets available.
 The projects may be focused on any area of open source contributions:
 code, documentation, test automation, advocacy, community management, etc.
 

--- a/mentorship/lfx-mentorship/README.md
+++ b/mentorship/lfx-mentorship/README.md
@@ -1,0 +1,41 @@
+# Keptn on LFX Mentorship
+
+[![LFX Mentorship](https://img.shields.io/badge/Profile-LFX%20Mentrorship-blue)](https://mentorship.lfx.linuxfoundation.org/project/ba41187f-fa8d-47e1-8046-4040e5b35b73)
+[![Channel on Slack](https://img.shields.io/badge/Slack-%23advocacy--and--outreach-green)](https://keptn.sh/community/#slack)
+
+The Keptn community can host mentorship and outreach programs using 
+[LFX Mentorship](https://lfx.linuxfoundation.org/tools/mentorship/).
+
+## Scope
+
+We can run projects there on ad-hoc basis,
+barring we have mentors and budgets available.
+The projects may be focused on any area of open source contributions:
+code, documentation, test automation, advocacy, community management, etc.
+
+## Apply as a mentee
+
+If you are interested in becoming in mentee,
+reach out to us in the `#advocacy-and-outreach` channel or
+in any working group channel
+relevant to your project idea.
+Usually LFX Mentorship is for established contributors
+with proven background in open source communities.
+
+If you are looking for possible project ideas,
+check out our
+[Google Summer of Code](../gsoc) and 
+[Google Season of Docs](../docs)
+project ideas
+that have not been started yet.
+Contributing to the initiatives from the
+[Keptn Roadmap](https://keptn.sh/docs/roadmap/) could be also a good project for LFX Mentorship.
+
+## References 
+
+* [Keptn page on LFX Mentorship](https://mentorship.lfx.linuxfoundation.org/project/ba41187f-fa8d-47e1-8046-4040e5b35b73)
+
+## Previous years
+
+- 2020 - _Keptn CLI to support multiple contexts like KUBECONFIG_ by Ankit Jain
+  ([project report](https://www.ankitjain28.me/communitybridge-mentee-with-keptn/)).


### PR DESCRIPTION
Improves documentation of our mentorship and outreach programs. Once merged, will add it to https://keptn.sh/community/contributing/#internships-and-mentorship-programs