### PR TITLE
gsoc22: add project timeline and issues link for new-docs-site-engine

### DIFF
--- a/mentorship/gsoc/2022/projects/new-docs-site-engine/README.md
+++ b/mentorship/gsoc/2022/projects/new-docs-site-engine/README.md
@@ -36,4 +36,4 @@ TODO
 - [Contributor GSoC 2022 repository](https://github.com/iamrajiv/GSoC-2022)
 - [Detailed GSoC 2022 Project Proposal](https://github.com/iamrajiv/GSoC-2022/blob/main/GSoC_2022_Project_Proposal.md)
 - [Project page at GSoC 2022 website](https://summerofcode.withgoogle.com/programs/2022/projects/whEHkPZx)
-- [Project timeline & issues](https://github.com/keptn-sandbox/new-keptn-docs-engine/issues)
+- [Project timeline & issues](https://github.com/keptn-sandbox/new-keptn-docs-engine/projects/1)

--- a/mentorship/gsoc/2022/projects/new-docs-site-engine/README.md
+++ b/mentorship/gsoc/2022/projects/new-docs-site-engine/README.md
@@ -36,3 +36,4 @@ TODO
 - [Contributor GSoC 2022 repository](https://github.com/iamrajiv/GSoC-2022)
 - [Detailed GSoC 2022 Project Proposal](https://github.com/iamrajiv/GSoC-2022/blob/main/GSoC_2022_Project_Proposal.md)
 - [Project page at GSoC 2022 website](https://summerofcode.withgoogle.com/programs/2022/projects/whEHkPZx)
+- [Project timeline & issues](https://github.com/keptn-sandbox/new-keptn-docs-engine/issues)


### PR DESCRIPTION
In response to https://keptn.slack.com/archives/C033WCZFMAR/p1655977050474659?thread_ts=1655408071.452999&cid=C033WCZFMAR