### PR TITLE
chore: Update link to members of Keptn organization

### DIFF
--- a/elections/2022/governance-committee-election.md
+++ b/elections/2022/governance-committee-election.md
@@ -45,7 +45,7 @@ The Pull Request will not be merged until the candidate has confirmed their desi
 
 # Voter Eligibility
 
-All [members of the Keptn Organization (Members, Approvers, Maintainers)](https://github.com/keptn/keptn/blob/main/MAINTAINERS.md) will automatically be eligible to vote.
+All [members of the Keptn Organization (Members, Approvers, Maintainers)](https://github.com/keptn/keptn/blob/master/MAINTAINERS) will automatically be eligible to vote.
 
 # Vote
 


### PR DESCRIPTION
Found a dead link in the 2022 election.
This PR adds the (hopefully) correct link: https://github.com/keptn/keptn/blob/master/MAINTAINERS
