### PR TITLE
fix: adapt module definition and fix typo

### DIFF
--- a/_index.md
+++ b/_index.md
@@ -2,7 +2,7 @@
 title: Community
 linktitle: Community
 type: docs
-description: Learn how to use Keptn.vasdfasdfsadf
+description: Learn how to use Keptn.
 cascade:
   type: docs
 menu:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aepfli/community
+module github.com/keptn/community
 
 go 1.19
 


### PR DESCRIPTION
During https://github.com/keptn/community/pull/246 a slight regression got caught based on the fact that the changes have been implemented in the fork.

This little code change should allow the integration of the community files from hugo as gomodules.