### PR TITLE
ci: use peribolos for team and team assignments

### DIFF
--- a/.github/workflows/peribolos.yaml
+++ b/.github/workflows/peribolos.yaml
@@ -8,9 +8,7 @@ on:
     branches: [ main ]
 
 env:
-  # Second step:
-  # PERIBOLOS_ARGS: "--fix-org --fix-org-members --fix-repos --fix-teams --fix-team-members --fix-team-repos --allow-repo-publish --allow-repo-archival --github-allowed-burst=300 --github-hourly-tokens=1000"
-  PERIBOLOS_ARGS: "--fix-org --fix-org-members --fix-repos --allow-repo-publish --allow-repo-archival --github-allowed-burst=300 --github-hourly-tokens=1000"
+  PERIBOLOS_ARGS: "--fix-org --fix-org-members --fix-repos --fix-teams --fix-team-members --fix-team-repos --allow-repo-publish --allow-repo-archival --github-allowed-burst=300 --github-hourly-tokens=1000"
 
 jobs:
   build:

--- a/.github/workflows/peribolos.yaml
+++ b/.github/workflows/peribolos.yaml
@@ -29,7 +29,7 @@ jobs:
         run: echo ${{ secrets.PERIBOLOS_GH_TOKEN }} >> github-token # a secret with the user token to be used for execution
 
       - name: Run Peribolos Configuration Verification
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: docker://ghcr.io/dynatrace-innovationlab/peribolos:v0
         with:
           args: ${{ env.PERIBOLOS_ARGS }} --github-token-path github-token --config-path peribolos.yaml

--- a/.github/workflows/peribolos.yaml
+++ b/.github/workflows/peribolos.yaml
@@ -6,6 +6,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+    - cron: "0 0 * * *"
 
 env:
   PERIBOLOS_ARGS: "--fix-org --fix-org-members --fix-repos --fix-teams --fix-team-members --fix-team-repos --allow-repo-publish --allow-repo-archival --github-allowed-burst=300 --github-hourly-tokens=1000"

--- a/tools/peribolosbuilder.go
+++ b/tools/peribolosbuilder.go
@@ -129,7 +129,7 @@ func loadOrgs(o options) (map[string]org.Config, error) {
 			for name := range cfg.Repos {
 				admins.Repos[name] = github.Admin
 				maintainers.Repos[name] = github.Maintain
-				approvers.Repos[name] = github.Triage
+				approvers.Repos[name] = github.Write
 				cfg.Repos[name] = applyRepoDefaults(cfg, name)
 			}
 
@@ -217,7 +217,7 @@ func generateGroupConfig(path string) (map[string]org.Team, error) {
 	for _, repo := range groupCfg.Repos {
 		admins.Repos[repo] = github.Admin
 		maintainers.Repos[repo] = github.Maintain
-		approvers.Repos[repo] = github.Triage
+		approvers.Repos[repo] = github.Write
 	}
 
 	teams := map[string]org.Team{}


### PR DESCRIPTION
In our first iteration, we activated peribolos for member assingments, with this pull request we will also use peribolos to create teams and assign members to teams, and give those teams permissions to certain repositories.