### PR TITLE
member: add agradnerIT to several workgroups

### DIFF
--- a/config/keptn/docs/workgroup.yaml
+++ b/config/keptn/docs/workgroup.yaml
@@ -9,3 +9,4 @@ approvers: []
 maintainers:
   - StackScribe
   - aepfli
+  - agardnerIT

--- a/config/keptn/lifecycle-toolkit/workgroup.yaml
+++ b/config/keptn/lifecycle-toolkit/workgroup.yaml
@@ -20,3 +20,4 @@ maintainers:
 # Approvers have write access to the repo, the scope is limited in CODEOWNERS
 approvers:
   - StackScribe
+  - agardnerIT


### PR DESCRIPTION
- as maintainer to docs, as he is heavily involved into docs furthermore with the discussion within https://github.com/keptn/lifecycle-toolkit/issues/1180 so he would be part of the CODEOWNERS of documentation
- as a approver to the klt repository, to grant the necessary write permissions

closes: #263