### PR TITLE
feat: grant TSC codeownership for community repo #270

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@
 # Learn about CODEOWNERS file format: 
 #  https://help.github.com/en/articles/about-code-owners
 #
-* @aloisreitbauer @AnaMMedina21 @AlexsJones
+* @keptn/governance-committee @keptn/technical-steering-committee

--- a/config/keptn/org.yaml
+++ b/config/keptn/org.yaml
@@ -90,6 +90,8 @@ teams:
 
   technical-steering-committee:
     members: []
+    repos:
+      community: write
 
   governance-committee:
     members:


### PR DESCRIPTION
The technical steering committee are entrusted members of the keptn organization. They know what we should and what we should not do. Therefore they are the ideal groups of members to support the governance committee in maintaining the community repository.

closes: #270