### PR TITLE
feat: grant aepfli approver status for lifecycle-toolkit

### DIFF
--- a/config/keptn/lifecycle-toolkit/workgroup.yaml
+++ b/config/keptn/lifecycle-toolkit/workgroup.yaml
@@ -21,3 +21,4 @@ maintainers:
 approvers:
   - StackScribe
   - agardnerIT
+  - aepfli


### PR DESCRIPTION
As @aepfli is heavily involved in the documentation and linter setup, it would be good to see the appprovals of this member as a real and valuable approval. Currently, as the member is not part this approval does not count for the number of needed approvals.

closes:  #239