### PR TITLE
feat: add klt repo to docs workgroup

### DIFF
--- a/config/keptn/docs/workgroup.yaml
+++ b/config/keptn/docs/workgroup.yaml
@@ -1,6 +1,7 @@
 
 repos:
   - keptn.github.io
+  - lifecycle-toolkit
   - tutorials
   - docs-tooling
 


### PR DESCRIPTION
We want to leverage code owners, but teams need to have write permissions to be used as codeowners. We will add the repo to the docs group. Which will allow them to be part of lifecycle-toolkit code owners.