### PR TITLE
feat: add write permission to TC for enhancement proposal repo

### DIFF
--- a/config/keptn/org.yaml
+++ b/config/keptn/org.yaml
@@ -97,6 +97,7 @@ teams:
       - thschue
     repos:
       community: write
+      enhancement-proposals: write
 
   governance-committee:
     members:


### PR DESCRIPTION
The role of the Technical Committee is to drive the technical decision for the project. Hence they should have access to merge/veto KEPs.