### PR TITLE
docs: update broken community link in membership.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership.md
+++ b/.github/ISSUE_TEMPLATE/membership.md
@@ -70,6 +70,6 @@ Please remember, it is an applicant's responsibility to get their sponsors' conf
 - Issues responded to
 - SIG projects I am involved with
 
-[Community Membership Guidelines]: https://github.com/keptn/community/blob/master/COMMUNITY_MEMBERSHIP.md
+[Community Membership Guidelines]: https://github.com/keptn/community/blob/main/community-membership.md
 [Peribolos Configuration]: ./config/keptn/org.yaml
 [Peribolos Configuration Directory]: ./config/keptn/


### PR DESCRIPTION
Changed "Community Membership Guidelines" 
FROM: 
https://github.com/keptn/community/blob/main/COMMUNITY_MEMBERSHIP.md

TO:
https://github.com/keptn/community/blob/main/community-membership.md