### PR TITLE
noissue: remove read-only repo from peribolos

### DIFF
--- a/config/keptn/org.yaml
+++ b/config/keptn/org.yaml
@@ -172,9 +172,6 @@ repos:
     default_branch: main
     description: GH Action to extract branch name for commits and PRs
     has_projects: false
-  gh-action-send-event:
-    default_branch: main
-    description: GH Action to send an event to a Keptn installation
   gh-automation:
     default_branch: main
     description: This repo is the single source of truth for pipelines that are shared

--- a/config/keptn/utils/workgroup.yaml
+++ b/config/keptn/utils/workgroup.yaml
@@ -1,6 +1,5 @@
 repos:
   - gh-action-extract-branch-name
-  - gh-action-send-event
   - gh-action-build-docker-image
   - gh-action-ci-prepare-keptn-cluster
 


### PR DESCRIPTION
https://github.com/keptn/gh-action-send-event has been archived. Hence, we should remove it from being tracked by Peribolos. 