### PR TITLE
fix community membership link

### DIFF
--- a/governance/members-and-charter.md
+++ b/governance/members-and-charter.md
@@ -80,5 +80,5 @@
  _Emeritus_.
  These roles are defined below.
 
- See [Community membership](./COMMUNITY_MEMBERSHIP.md) for additional information.
+ See [Community membership](../community-membership.md) for additional information.
 


### PR DESCRIPTION
This PR:

Fixes the broken hyperlink to the community membership page.
