### PR TITLE
remove mowies as admin and maintainer, move to emeriti

### DIFF
--- a/config/keptn/keptn/workgroup.yaml
+++ b/config/keptn/keptn/workgroup.yaml
@@ -33,5 +33,4 @@ maintainers:
   - DavidPHirsch
 
 admins:
-  - mowies
   - thisthat

--- a/config/keptn/lifecycle-toolkit/workgroup.yaml
+++ b/config/keptn/lifecycle-toolkit/workgroup.yaml
@@ -6,7 +6,6 @@ repos:
 
 # Admins have admin access to the repo
 admins:
-  - mowies
   - thisthat
   - thschue
 

--- a/config/keptn/org.yaml
+++ b/config/keptn/org.yaml
@@ -88,15 +88,14 @@ teams:
     members:
       - thschue
       - AloisReitbauer
+      - mowies
 
   admins:
     members:
-      - mowies
       - thisthat
 
   maintainers:
     members:
-      - mowies
       - thisthat
 
   approvers:


### PR DESCRIPTION
I'd like to remove myself as maintainer and admin since I don't really work on the project anymore.